### PR TITLE
Trigger backorder email on processing

### DIFF
--- a/wc-backorder-confirmation.php
+++ b/wc-backorder-confirmation.php
@@ -172,8 +172,8 @@ add_action( 'woocommerce_checkout_create_order', function( $order, $data ) {
     }
 }, 10, 2 );
 
-// 8) Dispara o e-mail ao notificar 'processing'
-add_action( 'woocommerce_order_status_processing_notification', function( $order_id ) {
+// 8) Dispara o e-mail quando o pedido entra em 'processing'
+function wcbc_trigger_backorder_email_on_processing( $order_id ) {
     $order = wc_get_order( $order_id );
     if ( $order && 'yes' === $order->get_meta( 'has_sob_encomenda' ) ) {
         $mailer = WC()->mailer();
@@ -182,4 +182,6 @@ add_action( 'woocommerce_order_status_processing_notification', function( $order
             $emails['WC_Email_Encomenda']->trigger( $order_id );
         }
     }
-}, 10, 1 );
+}
+
+add_action( 'woocommerce_order_status_processing', 'wcbc_trigger_backorder_email_on_processing', 10, 1 );


### PR DESCRIPTION
## Summary
- send `Encomenda` email whenever an order moves into the `processing` status

## Testing
- `php -l wc-backorder-confirmation.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_687a7a1eec98833183858112f76ebabc